### PR TITLE
Force HTTPS

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,12 @@
 0.0.0.0:9090 {
         root /var/www/public
         log stdout
-
         ext .html
+
+        redir 301 {
+                if {>X-Forwarded-Proto} is http
+                /  https://{host}{uri}
+        }
 
         errors {
                 404 errors/404/
@@ -56,6 +60,6 @@
                 header_upstream Host {host}
                 header_upstream X-Real-IP {remote}
                 header_upstream X-Forwarded-For {remote}
-                header_upstream X-Forwarded-Proto {scheme}
+                header_upstream X-Forwarded-Proto https
         }
 }


### PR DESCRIPTION
Since Caddy can not know if the request was done via `HTTPS` it was decided to force all requests to be `HTTPS`, and hardcode it under the `X-Forwarded-Proto` header