### PR TITLE
moved to cert-manager

### DIFF
--- a/helm-charts/docs/Chart.yaml
+++ b/helm-charts/docs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Chart to deploy docsrv on kubernetes
 name: docs
-version: 0.1.0
+version: 0.2.0
 maintainers:
   - name: Infrastructure team
     email: infra@sourced.tech

--- a/helm-charts/docs/templates/ingress.yaml
+++ b/helm-charts/docs/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    stable.k8s.psg.io/kcm.class: {{ .Values.ingress.kcmClass }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/helm-charts/docs/values.yaml
+++ b/helm-charts/docs/values.yaml
@@ -12,9 +12,9 @@ service:
   externalPort: 9090
   internalPort: 9090
 ingress:
-  kcmClass: default
   annotations:
     kubernetes.io/ingress.class: gce
+    kubernetes.io/tls-acme: "true"
   tls: true
   # globalStaticIpName must be received as a parameter
   # hosts list must be received as a parameter


### PR DESCRIPTION
We are removing kube-cert-manager as it is no longer supported

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>